### PR TITLE
Fix : Preserve diacritics in _resolve_wasl

### DIFF
--- a/pyarud/arudi.py
+++ b/pyarud/arudi.py
@@ -139,8 +139,11 @@ class ArudiConverter:
         1. Drop Long Vowel + Space + Alif Wasl (e.g. "Idhā Ishtadda" -> "Idhshtadda").
         2. Drop Space + Alif Wasl (e.g. "Bika Al-" -> "Bikal-").
         """
-        # Pattern: Letter + (Long Vowel) + Space + Alif -> Letter
-        text = re.sub(r"([^\s])([اىيو])\s+ا", r"\1", text)
+        # Pattern: Letter + (Optional Diacritic) + (Long Vowel) + Space + Alif -> Letter + Diacritic
+        # The original regex was flawed because it did not capture the diacritic.
+        # This version captures the letter and its optional diacritic, preserving it.
+        # Using S* to handle multiple diacritics (e.g., shadda + fatha).
+        text = re.sub(r"([^\s]\S*)([اىيو])\s+ا", r"\1", text)
         
         # Pattern: Space + Alif (Wasl) -> Drop both
         # Matches any word starting with bare Alif preceded by space.


### PR DESCRIPTION
🛠️ Issue:
The `_resolve_wasl` method was incorrectly dropping diacritics when handling the "Iltiqa al-Sakinayn" rule. This was due to a flawed regular expression that did not account for diacritics as separate characters.

🩹 Fix:
The fix updates the regex to correctly capture and preserve diacritics, ensuring the phonetic integrity of the text and accurate meter detection.

📄Example / مثال :

Input (النص الأصلي):
"دَعَا النَّاسُ"
(Note: The 'Ayn' has a Fatha, followed by Alif)

❌**Old Behavior**:
The regex failed to detect the pattern correctly because of the Fatha, or would strip the Fatha during replacement.
(يفشل في اكتشاف النمط بسبب وجود الفتحة، أو يقوم بحذف الفتحة أثناء المعالجة)

✅**New Behavior**:
"دَعَنَّاسُ"
(The Alif is dropped, but the Fatha on the 'Ayn' is preserved correctly)
(تم حذف الألف لمنع التقاء الساكنين، مع الحفاظ على فتحة حرف العين)

🛠️ The Problem with the Original (Old) Code
The original code assumed that the Arabic text is unvoweled (without Harakat), or that the vowel letter is immediately attached to the preceding letter without a separating Haraka.
This pattern looks for: (Letter) + (Harf Madd) directly.
Reality: In vocalized poetry, the letter is followed by a Haraka (Fatha, Damma, Kasra) before the Harf Madd.
Example: The phrase "فِي الْبَيْت".
The programmatic order of characters is: (Fa) + (Kasra) + (Ya) + (Space) + (Alif).